### PR TITLE
feat: add `unsigned` command option

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -228,6 +228,12 @@ internal object PatchCommand : Runnable {
         this.aaptBinaryPath = aaptBinaryPath
     }
 
+    @CommandLine.Option(
+        names = ["--unsigned"],
+        description = ["Disable signing of the final apk."],
+    )
+    private var unsigned: Boolean = false
+    
     override fun run() {
         // region Setup
 
@@ -332,7 +338,7 @@ internal object PatchCommand : Runnable {
         apk.copyTo(temporaryFilesPath.resolve(apk.name), overwrite = true).apply {
             patcherResult.applyTo(this)
         }.let { patchedApkFile ->
-            if (!mount) {
+            if (!mount && !unsigned) {
                 ApkUtils.signApk(
                     patchedApkFile,
                     outputFilePath,


### PR DESCRIPTION
This feature is useful for users with custom roms with signature verification disabled, or they are using [CorePatch](https://github.com/LSPosed/CorePatch). This avoids mounting and `Custom branding` works.

With this flag, you could copy the original signatures over the patched APK and install if signature verification is disabled and YouTube would work fine without the GMSCore support Patch, or you could mount the patched APK manually.

Code adapted from @inotia00
https://github.com/inotia00/revanced-cli/blob/ac715c38e1b17218e6d68b9507d1394dbed1f46b/src/main/kotlin/app/revanced/cli/command/PatchCommand.kt#L177-L181
https://github.com/inotia00/revanced-cli/blob/ac715c38e1b17218e6d68b9507d1394dbed1f46b/src/main/kotlin/app/revanced/cli/command/PatchCommand.kt#L346