### PR TITLE
fix: Do not log patch name more than once if disabled

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -381,7 +381,7 @@ internal object PatchCommand : Callable<Int> {
                     val enabledSelection = it.enabled!!
 
                     val resolvedName = enabledSelection.selector.name?.let { userInput ->
-                        patchesList.firstOrNull { it.name?.lowercase() == userInput.lowercase() }?.name ?: userInput
+                        patchesList.firstOrNull { it.name.equals(userInput, ignoreCase = true) }?.name ?: userInput
                     } ?: patchesList[enabledSelection.selector.index!!].name!!
 
                     resolvedName to enabledSelection.options


### PR DESCRIPTION
Moved the "compatibility check" block before the "patches get disabled" block making sure the cli keeps only the needed patches for our app and then disables those patches. Should fix #23