### PR TITLE
chore: Use local copies of morphe-patcher and morphe-library if available

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,20 @@
 rootProject.name = "morphe-cli"
+
+// Include morphe-patcher and morphe-library as composite builds if they exist locally
+val morphePatcherDir = file("../morphe-patcher")
+if (morphePatcherDir.exists()) {
+    includeBuild(morphePatcherDir) {
+        dependencySubstitution {
+            substitute(module("app.morphe:morphe-patcher")).using(project(":"))
+        }
+    }
+}
+
+val morpheLibraryDir = file("../morphe-library")
+if (morpheLibraryDir.exists()) {
+    includeBuild(morpheLibraryDir) {
+        dependencySubstitution {
+            substitute(module("app.morphe:morphe-library")).using(project(":"))
+        }
+    }
+}


### PR DESCRIPTION
This change makes it so that we don't need to fiddle with publishing to local maven + changing version numbers when testing changes to library or patcher. If those two repos are not checked out, then it will continue to pull the JARs from the defined Maven repositories; else Gradle will rebuild all the modified projects as needed.