### PR TITLE
fix: Scope loaded patches

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,10 @@ tasks {
         testLogging {
             events("PASSED", "SKIPPED", "FAILED")
         }
+        // Set heap size to 512 MB to check for OOM conditions.
+        minHeapSize = "512m"
+        maxHeapSize = "512m"
+        jvmArgs("-XX:+HeapDumpOnOutOfMemoryError")
     }
 
     processResources {

--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -327,14 +327,6 @@ internal object PatchCommand : Callable<Int> {
         var mergedApkToCleanup: File? = null
 
         try {
-            // region Load patches
-
-            logger.info("Loading patches")
-
-            val patches = loadPatchesFromJar(patchesFiles)
-
-            // endregion
-
             val patcherTemporaryFilesPath = temporaryFilesPath.resolve("patcher")
 
             // Checking if the file is in apkm format (like reddit)
@@ -363,7 +355,7 @@ internal object PatchCommand : Callable<Int> {
                     inputApk,
                     patcherTemporaryFilesPath,
                     aaptBinaryPath?.path,
-                    patcherTemporaryFilesPath.absolutePath,
+                    patcherTemporaryFilesPath.absolutePath
                 ),
             ).use { patcher ->
                 val packageName = patcher.context.packageMetadata.packageName
@@ -372,22 +364,30 @@ internal object PatchCommand : Callable<Int> {
                 patchingResult.packageName = packageName
                 patchingResult.packageVersion = packageVersion
 
-                val filteredPatches = patches.filterPatchSelection(packageName, packageVersion)
+                // region Load patches
 
-                logger.info("Setting patch options")
+                logger.info("Loading patches")
 
-                val patchesList = patches.toList()
-                selection.filter { it.enabled != null }.associate {
-                    val enabledSelection = it.enabled!!
+                // endregion
 
-                    val resolvedName = enabledSelection.selector.name?.let { userInput ->
-                        patchesList.firstOrNull { it.name.equals(userInput, ignoreCase = true) }?.name ?: userInput
-                    } ?: patchesList[enabledSelection.selector.index!!].name!!
+                loadPatchesFromJar(patchesFiles).let { patches ->
+                    val filteredPatches = patches.filterPatchSelection(packageName, packageVersion)
 
-                    resolvedName to enabledSelection.options
-                }.let(filteredPatches::setOptions)
+                    logger.info("Setting patch options")
 
-                patcher += filteredPatches
+                    val patchesList = patches.toList()
+                    selection.filter { it.enabled != null }.associate {
+                        val enabledSelection = it.enabled!!
+
+                        val resolvedName = enabledSelection.selector.name?.let { userInput ->
+                            patchesList.firstOrNull { it.name.equals(userInput, ignoreCase = true) }?.name ?: userInput
+                        } ?: patchesList[enabledSelection.selector.index!!].name!!
+
+                        resolvedName to enabledSelection.options
+                    }.let(filteredPatches::setOptions)
+
+                    patcher += filteredPatches
+                }
 
                 // Execute patches.
                 patchingResult.addStepResult(


### PR DESCRIPTION
Scope patches to a closure so that they go out of scope before patching begins. This will allow the JVM to garbage collect the patches and all associated state once the patcher cleans up its own references to the patches.