### PR TITLE
fix: Dispatch error when launching app

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,6 +152,8 @@ tasks {
             exclude(dependency("io.ktor:.*"))
             // Koin uses reflection
             exclude(dependency("io.insert-koin:.*"))
+            // Coroutines Swing provides Dispatchers.Main via ServiceLoader
+            exclude(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-swing"))
         }
 
         mergeServiceFiles()


### PR DESCRIPTION
Coroutines Swing provides Dispatchers.Main via ServiceLoader. We'll need to exclude this from minimize since it gets stripped otherwise.