### PR TITLE
feat: Inform user if cli is outdated

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -20,6 +20,7 @@ import app.morphe.cli.command.model.toPatchBundle
 import app.morphe.cli.command.model.toSerializablePatch
 import app.morphe.cli.command.model.withUpdatedBundle
 import app.morphe.engine.ApkLibraryStripper
+import app.morphe.engine.UpdateChecker
 import app.morphe.patcher.apk.ApkUtils
 import app.morphe.patcher.apk.ApkUtils.applyTo
 import app.morphe.library.installation.installer.*
@@ -318,6 +319,9 @@ internal object PatchCommand : Callable<Int> {
     private var updateOptions: Boolean = false
 
     override fun call(): Int {
+        // Check for any newer version
+        UpdateChecker.check()?.let { logger.info(it) }
+
         // region Setup
 
         val outputFilePath =

--- a/src/main/kotlin/app/morphe/engine/UpdateChecker.kt
+++ b/src/main/kotlin/app/morphe/engine/UpdateChecker.kt
@@ -1,0 +1,41 @@
+package app.morphe.engine
+
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Properties
+
+
+object UpdateChecker {
+    fun check(): String? {
+        try {
+            // Try to get the latest version. (TTL IS SET TO 3000)
+            val currentVersion = javaClass.getResourceAsStream("/app/morphe/cli/version.properties")
+                ?.use { stream ->
+                    Properties().apply { load(stream) }.getProperty("version")
+                }
+                ?: return null
+
+            val connection = URL("https://api.github.com/repos/MorpheApp/morphe-cli/releases/latest")
+                .openConnection() as HttpURLConnection
+
+            connection.connectTimeout = 3000
+            connection.readTimeout = 3000
+            connection.setRequestProperty("Accept", "application/vnd.github.v3+json")
+
+            //
+            val response = connection.getInputStream().bufferedReader().use { it.readText() }
+
+            val latestVersion = Regex(""""tag_name"\s*:\s*"v?([^"]+)"""").find(response)
+                ?.groupValues?.get(1) ?: return null
+
+            if (latestVersion != currentVersion) {
+                return "Update available: v$latestVersion (current: v$currentVersion). Download from https://github.com/MorpheApp/morphe-cli/releases/latest"
+            }
+            return  null
+
+        }catch (e: Exception) {
+            // In case we fail anything, we silently return.
+            return null
+        }
+    }
+}


### PR DESCRIPTION
Check the user's version with the latest stable version to see if the user's version is outdated. Currently it only runs with the patch subcommand and the network connection has a 3 sec TTL. Any errors are silently thrown and the patching continues. Do we reduce the TTL or is this fine? 

It is running on the main thread itself, but it'll block it max for 3 seconds. In case there are any issues with this implementation, please let me know. I'll make the changes