### PR TITLE
fix: Use GitHub raw links for CLI update check

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -320,7 +320,7 @@ internal object PatchCommand : Callable<Int> {
 
     override fun call(): Int {
         // Check for any newer version
-        UpdateChecker.check()?.let { logger.info(it) }
+        UpdateChecker.check(logger)?.let { logger.info(it) }
 
         // region Setup
 

--- a/src/main/kotlin/app/morphe/engine/UpdateChecker.kt
+++ b/src/main/kotlin/app/morphe/engine/UpdateChecker.kt
@@ -3,29 +3,29 @@ package app.morphe.engine
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.Properties
-
+import java.util.logging.Logger
 
 object UpdateChecker {
-    fun check(): String? {
+    fun check(logger: Logger): String? {
         try {
-            // Try to get the latest version. (TTL IS SET TO 3000)
+            // Current version of this CLI.
             val currentVersion = javaClass.getResourceAsStream("/app/morphe/cli/version.properties")
                 ?.use { stream ->
                     Properties().apply { load(stream) }.getProperty("version")
-                }
-                ?: return null
+                } ?: return null
 
-            // Check if the user is using dev or stable release here. Then we use this to check the latest dev or stable release.
+            // Check if the user is using dev or stable release.
             val isDev = currentVersion.contains("dev")
 
             val url = if (isDev) {
+                // If on dev and a new stable release is available, then this
+                // ref still is correct because after a stable release dev branch is same as main.
                 "https://raw.githubusercontent.com/MorpheApp/morphe-cli/refs/heads/dev/gradle.properties"
             } else {
                 "https://raw.githubusercontent.com/MorpheApp/morphe-cli/refs/heads/main/gradle.properties"
             }
 
             val connection = URL(url).openConnection() as HttpURLConnection
-
             connection.connectTimeout = 3000
             connection.readTimeout = 3000
 
@@ -36,25 +36,26 @@ object UpdateChecker {
             }.getProperty("version") ?: return null
 
             if (latestVersion != currentVersion) {
-                val currentTag = if (isDev) "[Dev]" else "[Stable]"
-                val latestTag = if (latestVersion.contains("dev")) "[Dev]" else "[Stable]"
-
                 // Warning message for when the user is to about to move from dev -> stable edge case.
                 val trackChangesMessage = if (isDev && !latestVersion.contains("dev")){
-                    "\nWarning: This is a stable release. Updating will stop dev update notifications. " +
-                            "To keep receiving dev updates, skip this and wait for the next dev release."
+                    "\nNotice: The latest CLI is a stable release. Updating to that will stop dev " +
+                            "update notifications. To keep receiving dev updates, skip stable update " +
+                            "and wait for the next dev release."
                 } else ""
 
-                return if (isDev){
-                    "Update available: v$latestVersion $latestTag (current: v$currentVersion $currentTag).$trackChangesMessage\nDownload from https://github.com/MorpheApp/morphe-cli/releases/"
+                val downloadLink = if (isDev) {
+                    "https://github.com/MorpheApp/morphe-cli/releases/"
                 } else {
-                    "Update available: v$latestVersion $latestTag (current: v$currentVersion $currentTag).$trackChangesMessage\nDownload from https://github.com/MorpheApp/morphe-cli/releases/latest"
+                    "https://github.com/MorpheApp/morphe-cli/releases/latest"
                 }
+
+                return "Update available: v$latestVersion (current: v$currentVersion)" +
+                        "$trackChangesMessage\nDownload from $downloadLink"
             }
             return  null
 
-        }catch (e: Exception) {
-            // In case we fail anything, we silently return.
+        } catch (ex: Exception) {
+            logger.fine("Could not check for CLI update: $ex")
             return null
         }
     }


### PR DESCRIPTION
Update messages now check for dev and stable releases properly and suggests updates accordingly.