### PR TITLE
fix: Handle patching XAPK files

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -431,9 +431,11 @@ internal object PatchCommand : Callable<Int> {
 
             val patcherTemporaryFilesPath = temporaryFilesPath.resolve("patcher")
 
-            // Checking if the file is in apkm format (like reddit)
-            val inputApk = if (apk.extension.equals("apkm", ignoreCase = true)) {
-                logger.info("Merging APKM bundle")
+            // We need to check for both apkm (like reddit) and xapk formats here
+
+            val inputApk = if (apk.extension.lowercase() in  setOf("apkm", "xapk")) {
+
+                logger.info("Merging split APK bundle")
 
                 // Save merged APK to output directory (will be cleaned up after patching)
                 val outputApk = outputFilePath.parentFile.resolve("${apk.nameWithoutExtension}-merged.apk")

--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -431,9 +431,9 @@ internal object PatchCommand : Callable<Int> {
 
             val patcherTemporaryFilesPath = temporaryFilesPath.resolve("patcher")
 
-            // We need to check for both apkm (like reddit) and xapk formats here
+            // We need to check for apkm (like reddit), xapk and apks formats here
 
-            val inputApk = if (apk.extension.lowercase() in  setOf("apkm", "xapk")) {
+            val inputApk = if (apk.extension.lowercase() in  setOf("apkm", "xapk", "apks")) {
 
                 logger.info("Merging split APK bundle")
 
@@ -754,7 +754,7 @@ internal object PatchCommand : Callable<Int> {
                 purge(temporaryFilesPath)
             }
 
-            // Clean up merged APK if we created one from APKM
+            // Clean up merged apk if we created one from apkm, xapk or apks
             mergedApkToCleanup?.let {
                 if (!it.delete()) {
                     logger.warning("Could not clean up merged APK: ${it.path}")


### PR DESCRIPTION
The problem was cli was hard checking to only match apkm. Any other format would fall into the else branch and be considered as an apk. Now it checks for apkm and xapk.