### PR TITLE
fix: Handle running CLI in headless environment

### DIFF
--- a/src/main/kotlin/app/morphe/MorpheLauncher.kt
+++ b/src/main/kotlin/app/morphe/MorpheLauncher.kt
@@ -6,12 +6,19 @@
 package app.morphe
 
 import app.morphe.library.logging.Logger
+import java.awt.GraphicsEnvironment
 
 fun main(args: Array<String>) {
-    if (args.isEmpty()) {
+    if (args.isEmpty() && !GraphicsEnvironment.isHeadless()) {
         app.morphe.gui.launchGui(args)
     } else {
         Logger.setDefault()
+
+        if (GraphicsEnvironment.isHeadless()){
+            val logger = java.util.logging.Logger.getLogger("app.morphe.MorpheLauncher")
+            logger.info("Running in Headless environment, falling back to CLI mode.")
+        }
+
         picocli.CommandLine(app.morphe.cli.command.MainCommand)
             .execute(*args)
             .let(System::exit)


### PR DESCRIPTION
When the jar file is run, it checks if it is running in a headless environment. In case it is, it falls back to cli entry even if no args are passed (this would previously try to load the gui, fail and then throw an error).