### PR TITLE
fix: Notice and License in shadow JAR fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.compose)
-    alias(libs.plugins.shadow)
+    // Shadow plugin is provided by buildSrc to enable the custom NoticeMergeTransformer.
+    // Applied without a version here; the version is pinned in buildSrc/build.gradle.kts.
+    id("com.gradleup.shadow")
     application
     `maven-publish`
     signing
@@ -138,6 +140,12 @@ tasks {
         filesMatching("**/*.properties") {
             expand("projectVersion" to project.version)
         }
+        // Bundle the project's NOTICE (GPL 7b/7c) and LICENSE into META-INF so they
+        // land in the main JAR before the Shadow merge. Source of truth stays at the
+        // repo root — these are copied at build time, not duplicated in source control.
+        from(arrayOf(rootProject.file("NOTICE"), rootProject.file("LICENSE"))) {
+            into("META-INF")
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -149,6 +157,32 @@ tasks {
             "/prebuilt/windows/aapt.exe",
             "/prebuilt/*/aapt_*",
         )
+
+        // NOTICE/LICENSE handling:
+        //   * Global strategy is EXCLUDE (first-wins) so duplicates at non-transformed
+        //     paths — including native libs like libskiko-*.dylib — are deduplicated.
+        //     INCLUDE globally would double-pack every colliding resource and bloat the
+        //     JAR by tens of MB.
+        //   * For META-INF/NOTICE* paths specifically, strategy is flipped to INCLUDE
+        //     via filesMatching below so all dep NOTICEs reach NoticeMergeTransformer
+        //     (Shadow drops duplicates before transformers run under EXCLUDE — see
+        //     ShadowJar.kt Kdoc).
+        //   * Root /NOTICE and /LICENSE — our project's files, added below via from().
+        //     With EXCLUDE, the first occurrence wins. Dep JARs with root-level NOTICE/
+        //     LICENSE lose because our from() block is declared before Shadow processes
+        //     dependency configurations.
+        //   * META-INF/LICENSE — our GPL LICENSE, placed via processResources so it
+        //     lands in the main JAR ahead of dep copies. Dep LICENSE files at unique
+        //     paths (META-INF/androidx/**/LICENSE.txt, etc.) are preserved untouched.
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        filesMatching(listOf(
+            "META-INF/NOTICE",
+            "META-INF/NOTICE.txt",
+            "META-INF/NOTICE.md",
+        )) {
+            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        }
+        from(rootProject.file("NOTICE"), rootProject.file("LICENSE"))
         minimize {
             exclude(dependency("org.bouncycastle:.*"))
             exclude(dependency("app.morphe:morphe-patcher"))
@@ -163,6 +197,16 @@ tasks {
         }
 
         mergeServiceFiles()
+
+        // Concatenate every META-INF/NOTICE (and .txt/.md variants) from all dep JARs
+        // plus our own into a single merged file. Satisfies Apache 2.0 §4(d) which
+        // requires preserving attribution NOTICEs of Apache-licensed dependencies.
+        //
+        // Shadow's built-in ApacheNoticeResourceTransformer hardcodes ASF-branded
+        // copyright text that cannot be fully disabled, which would falsely attribute
+        // this GPL project to the Apache Software Foundation. NoticeMergeTransformer
+        // (in buildSrc) is a minimal verbatim concatenator with no boilerplate.
+        transform(NoticeMergeTransformer::class.java)
     }
 
     distTar {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    // Shadow is declared as implementation so the root project's build script
+    // gets these classes on its buildscript classpath at runtime. The root
+    // project must then apply the shadow plugin without a version to avoid
+    // the "plugin is already on the classpath" conflict.
+    implementation("com.gradleup.shadow:shadow-gradle-plugin:9.3.2")
+    implementation("org.jetbrains:annotations:24.1.0")
+}

--- a/buildSrc/src/main/java/NoticeMergeTransformer.java
+++ b/buildSrc/src/main/java/NoticeMergeTransformer.java
@@ -1,0 +1,115 @@
+import com.github.jengelman.gradle.plugins.shadow.transformers.CacheableTransformer;
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer;
+import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import javax.inject.Inject;
+import org.apache.tools.zip.ZipEntry;
+import org.apache.tools.zip.ZipOutputStream;
+import org.gradle.api.file.FileTreeElement;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Concatenates matched resource files across dependency JARs into a single
+ * output entry. Unlike Shadow's ApacheNoticeResourceTransformer this injects
+ * no ASF-branded boilerplate, which is required for a GPL project that must
+ * preserve third-party NOTICEs verbatim without falsely attributing itself
+ * to the Apache Software Foundation.
+ *
+ * Path matching is case-insensitive so NOTICE / NOTICE.txt / NOTICE.md are
+ * all merged into the same output file. Shadow processes main source set
+ * resources before dependency JARs, so when the project's NOTICE is shipped
+ * via processResources it naturally appears first in the merged output.
+ *
+ * Written in Java to avoid Kotlin metadata version conflicts between the
+ * buildSrc compiler and the Shadow plugin classes.
+ */
+@CacheableTransformer
+public abstract class NoticeMergeTransformer implements ResourceTransformer {
+
+    private static final String DEFAULT_SEPARATOR =
+            "\n\n----------------------------------------------------------------\n\n";
+    private static final List<String> DEFAULT_PATHS = Arrays.asList(
+            "META-INF/NOTICE",
+            "META-INF/NOTICE.txt",
+            "META-INF/NOTICE.md"
+    );
+
+    private final ObjectFactory objectFactory;
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    private int sectionCount = 0;
+
+    @Inject
+    public NoticeMergeTransformer(ObjectFactory objectFactory) {
+        this.objectFactory = objectFactory;
+        getOutputPath().convention("META-INF/NOTICE");
+        getMatchedPaths().convention(DEFAULT_PATHS);
+        getSeparator().convention(DEFAULT_SEPARATOR);
+    }
+
+    @Input
+    public abstract Property<String> getOutputPath();
+
+    @Input
+    public abstract ListProperty<String> getMatchedPaths();
+
+    @Input
+    public abstract Property<String> getSeparator();
+
+    @Internal
+    @NotNull
+    @Override
+    public ObjectFactory getObjectFactory() {
+        return objectFactory;
+    }
+
+    @Override
+    public boolean canTransformResource(@NotNull FileTreeElement element) {
+        String path = element.getRelativePath().getPathString();
+        for (String matched : getMatchedPaths().get()) {
+            if (matched.equalsIgnoreCase(path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void transform(@NotNull TransformerContext context) throws IOException {
+        if (sectionCount > 0) {
+            buffer.write(getSeparator().get().getBytes(StandardCharsets.UTF_8));
+        }
+        byte[] readBuf = new byte[8192];
+        int n;
+        while ((n = context.getInputStream().read(readBuf)) != -1) {
+            buffer.write(readBuf, 0, n);
+        }
+        sectionCount++;
+    }
+
+    @Override
+    public boolean hasTransformedResource() {
+        return sectionCount > 0;
+    }
+
+    @Override
+    public void modifyOutputStream(@NotNull ZipOutputStream os, boolean preserveFileTimestamps) throws IOException {
+        ZipEntry entry = new ZipEntry(getOutputPath().get());
+        if (!preserveFileTimestamps) {
+            entry.setTime(0);
+        }
+        os.putNextEntry(entry);
+        os.write(buffer.toByteArray());
+        os.closeEntry();
+        buffer.reset();
+        sectionCount = 0;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 # Core
-shadow = "9.3.2"
 junit = "5.11.0"
 kotlin = "2.3.20"
 
@@ -84,4 +83,3 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
-shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }


### PR DESCRIPTION
The project's NOTICE and LICENSE were never being added to the shipped `-all.jar`, so dep files won the path collision and users saw the Apache License at `/NOTICE` instead of Morphe's GPL 7b/7c. This fix adds ours explicitly at root and `META-INF/`, and concatenates dep NOTICEs beneath via a custom Shadow transformer (the built-in one hardcodes ASF attribution).


Please check if this enough. Or if we need to do something else.