### PR TITLE
fix: continue-on-error fix + force windows to `FULL`

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -10,6 +10,7 @@ package app.morphe.cli.command
 
 import app.morphe.cli.command.model.*
 import app.morphe.engine.PatchEngine
+import app.morphe.engine.isWindows
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_KEYSTORE_ALIAS
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_KEYSTORE_PASSWORD
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_SIGNER_NAME
@@ -542,7 +543,11 @@ internal object PatchCommand : Callable<Int> {
                     patcherTemporaryFilesPath.absolutePath,
                     useArsclib = if (aaptBinaryPath != null) { false } else { !forceApktool },
                     keepArchitectures = keepArchitectures,
-                    useBytecodeMode = bytecodeMode,
+                    /*
+                    TODO: Remove Windows override once the patcher ships its proper fix
+                     (reflection-based MappedByteBuffer release + copy-instead-of-rename for output DEX files).
+                     */
+                    useBytecodeMode = if (isWindows()) { BytecodeMode.FULL } else { bytecodeMode },
                     verifier = verifier
                 ),
             ).use { patcher ->
@@ -694,9 +699,9 @@ internal object PatchCommand : Callable<Int> {
                                                 writer.toString()
                                             )
                                         )
-                                        patchingResult.success = false
 
                                         if (!continueOnError) {
+                                            patchingResult.success = false
                                             throw PatchFailedException(
                                                 "\"${patchResult.patch}\" failed",
                                                 exception

--- a/src/main/kotlin/app/morphe/engine/PatchEngine.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchEngine.kt
@@ -57,6 +57,7 @@ object PatchEngine {
         val aaptBinaryPath: File? = null,
         val tempDir: File? = null,
         val failOnError: Boolean = true,
+        val bytecodeMode: BytecodeMode = BytecodeMode.STRIP_FAST
     ) {
         companion object {
             internal const val DEFAULT_KEYSTORE_ALIAS = "Morphe"
@@ -127,7 +128,11 @@ object PatchEngine {
                 patcherTempDir.absolutePath,
                 useArsclib = true,
                 keepArchitectures = config.architecturesToKeep,
-                useBytecodeMode = BytecodeMode.STRIP_FAST
+                /*
+                TODO: Remove Windows override once the patcher ships its proper fix
+                 (reflection-based MappedByteBuffer release + copy-instead-of-rename for output DEX files).
+                 */
+                useBytecodeMode = if (isWindows()) { BytecodeMode.FULL } else { config.bytecodeMode }
             )
 
             Patcher(patcherConfig).use { patcher ->
@@ -281,8 +286,13 @@ object PatchEngine {
 
                 onProgress("Patching complete!")
 
+                // When failOnError=false (user asked to continue on error), reaching this
+                // line means the APK was successfully rebuilt from the patches that worked,
+                // treat the run as a success. Individual failures are still reported via
+                // `failedPatches` for the UI to display. Only strict mode (failOnError=true)
+                // treats any failure as an overall failure.
                 return Result(
-                    success = failedPatches.isEmpty(),
+                    success = if (config.failOnError) failedPatches.isEmpty() else true,
                     outputPath = config.outputApk.absolutePath,
                     packageName = packageName,
                     packageVersion = packageVersion,

--- a/src/main/kotlin/app/morphe/engine/PlatformCheck.kt
+++ b/src/main/kotlin/app/morphe/engine/PlatformCheck.kt
@@ -1,0 +1,5 @@
+package app.morphe.engine
+
+internal fun isWindows(): Boolean {
+    return System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+}

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patching/PatchingViewModel.kt
@@ -84,7 +84,21 @@ class PatchingViewModel(
             result.fold(
                 onSuccess = { patchResult ->
                     if (patchResult.success) {
-                        addLog("Patching completed successfully!", LogLevel.SUCCESS)
+                        // Distinguish clean success from "continue-on-error" partial success:
+                        // the APK was built, but some patches were skipped. Log the skipped
+                        // ones as a warning so the user sees what didn't apply.
+                        if (patchResult.failedPatches.isNotEmpty()) {
+                            addLog(
+                                "Patching completed with ${patchResult.failedPatches.size} patches skipped",
+                                LogLevel.WARNING
+                            )
+                            addLog(
+                                "Skipped patches: ${patchResult.failedPatches.joinToString(", ")}",
+                                LogLevel.WARNING
+                            )
+                        } else {
+                            addLog("Patching completed successfully!", LogLevel.SUCCESS)
+                        }
                         addLog("Applied ${patchResult.appliedPatches.size} patches", LogLevel.SUCCESS)
                         _uiState.value = _uiState.value.copy(
                             status = PatchingStatus.COMPLETED,


### PR DESCRIPTION
Fixed an issue where continue-on-error would fail sometimes even though it is not supposed to.
Windows now forces `FULL` BytecodeMode. (Temp fix until wchill's permanent fix)