### PR TITLE
feat: Custom output path + better GUI scrollbars

### DIFF
--- a/src/main/kotlin/app/morphe/gui/ui/components/MorpheScrollbar.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/MorpheScrollbar.kt
@@ -7,6 +7,7 @@ package app.morphe.gui.ui.components
 
 import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -28,7 +29,7 @@ fun morpheScrollbarStyle(
     return ScrollbarStyle(
         minimalHeight = minimalHeight,
         thickness = thickness,
-        shape = RoundedCornerShape(corners.small),
+        shape = if (corners.small >= 8.dp) RoundedCornerShape(corners.small) else RectangleShape,
         hoverDurationMillis = 0,
         unhoverColor = accent.copy(alpha = idleAlpha),
         hoverColor = accent

--- a/src/main/kotlin/app/morphe/gui/ui/components/MorpheScrollbar.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/MorpheScrollbar.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-cli
+ */
+
+package app.morphe.gui.ui.components
+
+import androidx.compose.foundation.ScrollbarStyle
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import app.morphe.gui.ui.theme.LocalMorpheAccents
+import app.morphe.gui.ui.theme.LocalMorpheCorners
+
+/**
+ * Shared scrollbar style. Always-visible accent thumb, corners pulled from
+ * the active Morphe theme so the scrollbar matches the rest of the geometry.
+ */
+@Composable
+fun morpheScrollbarStyle(
+    thickness: Dp = 6.dp,
+    minimalHeight: Dp = 24.dp,
+    idleAlpha: Float = 0.55f
+): ScrollbarStyle {
+    val accent = LocalMorpheAccents.current.primary
+    val corners = LocalMorpheCorners.current
+    return ScrollbarStyle(
+        minimalHeight = minimalHeight,
+        thickness = thickness,
+        shape = RoundedCornerShape(corners.small),
+        hoverDurationMillis = 0,
+        unhoverColor = accent.copy(alpha = idleAlpha),
+        hoverColor = accent
+    )
+}

--- a/src/main/kotlin/app/morphe/gui/ui/components/SettingsButton.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SettingsButton.kt
@@ -58,6 +58,7 @@ fun SettingsButton(
 
     var showSettingsDialog by remember { mutableStateOf(false) }
     var autoCleanupTempFiles by remember { mutableStateOf(true) }
+    var defaultOutputDirectory by remember { mutableStateOf<String?>(null) }
     var patchSources by remember { mutableStateOf<List<PatchSource>>(emptyList()) }
     var activePatchSourceId by remember { mutableStateOf("") }
     var keystorePath by remember { mutableStateOf<String?>(null) }
@@ -71,6 +72,7 @@ fun SettingsButton(
         if (showSettingsDialog) {
             val config = configRepository.loadConfig()
             autoCleanupTempFiles = config.autoCleanupTempFiles
+            defaultOutputDirectory = config.defaultOutputDirectory
             patchSources = config.patchSource
             activePatchSourceId = config.activePatchSourceId
             keystorePath = config.keystorePath
@@ -118,6 +120,11 @@ fun SettingsButton(
                 scope.launch {
                     configRepository.setAutoCleanupTempFiles(enabled)
                 }
+            },
+            defaultOutputDirectory = defaultOutputDirectory,
+            onDefaultOutputDirectoryChange = { path ->
+                defaultOutputDirectory = path
+                scope.launch { configRepository.setDefaultOutputDirectory(path) }
             },
             useExpertMode = !modeState.isSimplified,
             onExpertModeChange = { enabled ->

--- a/src/main/kotlin/app/morphe/gui/ui/components/SettingsDialog.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SettingsDialog.kt
@@ -630,7 +630,8 @@ private fun LicensesDialog(onDismiss: () -> Unit) {
                                     .align(Alignment.CenterEnd)
                                     .fillMaxHeight()
                                     .padding(vertical = 6.dp),
-                                adapter = rememberScrollbarAdapter(listState)
+                                adapter = rememberScrollbarAdapter(listState),
+                                style = morpheScrollbarStyle()
                             )
                         }
                     }
@@ -1118,7 +1119,8 @@ private fun LicenseTextDialog(license: License, onDismiss: () -> Unit) {
                                 .align(Alignment.CenterEnd)
                                 .fillMaxHeight()
                                 .padding(vertical = 6.dp),
-                            adapter = rememberScrollbarAdapter(scrollState)
+                            adapter = rememberScrollbarAdapter(scrollState),
+                            style = morpheScrollbarStyle()
                         )
                     } else {
                         Column(

--- a/src/main/kotlin/app/morphe/gui/ui/components/SettingsDialog.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/components/SettingsDialog.kt
@@ -47,6 +47,7 @@ import java.awt.Desktop
 import java.awt.FileDialog
 import java.awt.Frame
 import java.io.File
+import javax.swing.JFileChooser
 import java.security.KeyStore
 import java.security.MessageDigest
 import java.security.cert.X509Certificate
@@ -83,6 +84,8 @@ fun SettingsDialog(
     onThemeChange: (ThemePreference) -> Unit,
     autoCleanupTempFiles: Boolean,
     onAutoCleanupChange: (Boolean) -> Unit,
+    defaultOutputDirectory: String?,
+    onDefaultOutputDirectoryChange: (String?) -> Unit,
     useExpertMode: Boolean,
     onExpertModeChange: (Boolean) -> Unit,
     onDismiss: () -> Unit,
@@ -216,6 +219,17 @@ fun SettingsDialog(
                     onCheckedChange = onAutoCleanupChange,
                     accentColor = accents.primary,
                     mono = mono,
+                    enabled = !isPatching
+                )
+
+                SettingsDivider(borderColor)
+
+                // ── Output Folder ──
+                OutputFolderSection(
+                    defaultOutputDirectory = defaultOutputDirectory,
+                    onDefaultOutputDirectoryChange = onDefaultOutputDirectoryChange,
+                    mono = mono,
+                    borderColor = borderColor,
                     enabled = !isPatching
                 )
 
@@ -1312,6 +1326,126 @@ private fun SettingToggleRow(
             accentColor = accentColor,
             enabled = enabled
         )
+    }
+}
+
+@Composable
+private fun OutputFolderSection(
+    defaultOutputDirectory: String?,
+    onDefaultOutputDirectoryChange: (String?) -> Unit,
+    mono: androidx.compose.ui.text.font.FontFamily,
+    borderColor: Color,
+    enabled: Boolean = true
+) {
+    val corners = LocalMorpheCorners.current
+    val alpha = if (enabled) 1f else 0.4f
+    val outputDir = defaultOutputDirectory?.let { File(it) }
+    val outputDirExists = outputDir?.isDirectory == true
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        SectionLabel("OUTPUT FOLDER", mono)
+        Spacer(Modifier.height(6.dp))
+
+        Text(
+            text = if (!enabled) "Disabled while patching"
+                   else "Where patched APKs are saved. A per-app subfolder is created inside.",
+            fontSize = 11.sp,
+            fontFamily = mono,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f * alpha)
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(corners.small))
+                    .border(1.dp, borderColor, RoundedCornerShape(corners.small))
+                    .padding(horizontal = 10.dp),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Text(
+                    text = outputDir?.name ?: "APK's folder (default)",
+                    fontSize = 11.sp,
+                    fontFamily = mono,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f * alpha),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            OutlinedButton(
+                onClick = {
+                    val chooser = JFileChooser().apply {
+                        dialogTitle = "Select Output Folder"
+                        fileSelectionMode = JFileChooser.DIRECTORIES_ONLY
+                        isAcceptAllFileFilterUsed = false
+                        outputDir?.takeIf { it.isDirectory }?.let { currentDirectory = it }
+                    }
+                    if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+                        onDefaultOutputDirectoryChange(chooser.selectedFile.absolutePath)
+                    }
+                },
+                enabled = enabled,
+                shape = RoundedCornerShape(corners.small),
+                border = BorderStroke(1.dp, borderColor),
+                contentPadding = PaddingValues(horizontal = 10.dp),
+                modifier = Modifier.fillMaxHeight()
+            ) {
+                Text(
+                    "BROWSE",
+                    fontFamily = mono,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 9.sp,
+                    letterSpacing = 0.5.sp
+                )
+            }
+
+            if (defaultOutputDirectory != null) {
+                OutlinedButton(
+                    onClick = { onDefaultOutputDirectoryChange(null) },
+                    enabled = enabled,
+                    shape = RoundedCornerShape(corners.small),
+                    border = BorderStroke(1.dp, borderColor),
+                    contentPadding = PaddingValues(horizontal = 10.dp),
+                    modifier = Modifier.fillMaxHeight()
+                ) {
+                    Text(
+                        "RESET",
+                        fontFamily = mono,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 9.sp,
+                        letterSpacing = 0.5.sp
+                    )
+                }
+            }
+        }
+
+        if (defaultOutputDirectory != null && !outputDirExists) {
+            Text(
+                text = "Folder not found — will be created on next patch",
+                fontSize = 10.sp,
+                fontFamily = mono,
+                color = Color(0xFFE0A030)
+            )
+        }
+
+        if (defaultOutputDirectory != null) {
+            Text(
+                text = defaultOutputDirectory,
+                fontSize = 9.sp,
+                fontFamily = mono,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }
 

--- a/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/home/HomeScreen.kt
@@ -20,7 +20,9 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.HorizontalScrollbar
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -63,6 +65,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import app.morphe.gui.data.model.SupportedApp
 import app.morphe.gui.ui.components.TopBarRow
+import app.morphe.gui.ui.components.morpheScrollbarStyle
 import app.morphe.gui.ui.screens.home.components.ApkInfoCard
 import app.morphe.gui.ui.screens.home.components.FullScreenDropZone
 import app.morphe.gui.ui.components.OfflineBanner
@@ -1402,20 +1405,33 @@ private fun SupportedAppsMasterDetail(
         val parentWidth = maxWidth
         val scrollState = rememberScrollState()
 
-        Row(
-            modifier = Modifier
-                .horizontalScroll(scrollState)
-                .widthIn(min = parentWidth)
-                .padding(horizontal = 8.dp, vertical = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(cardSpacing, Alignment.CenterHorizontally),
-            verticalAlignment = Alignment.Top
-        ) {
-            apps.forEach { app ->
-                SupportedAppVerticalCard(
-                    app = app,
-                    isSelected = app.packageName == selectedApp?.packageName,
-                    onClick = { onSelect(app) },
-                    isDefaultSource = isDefaultSource
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .horizontalScroll(scrollState)
+                    .widthIn(min = parentWidth)
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(cardSpacing, Alignment.CenterHorizontally),
+                verticalAlignment = Alignment.Top
+            ) {
+                apps.forEach { app ->
+                    SupportedAppVerticalCard(
+                        app = app,
+                        isSelected = app.packageName == selectedApp?.packageName,
+                        onClick = { onSelect(app) },
+                        isDefaultSource = isDefaultSource
+                    )
+                }
+            }
+
+            if (scrollState.maxValue > 0) {
+                Spacer(Modifier.height(6.dp))
+                HorizontalScrollbar(
+                    adapter = rememberScrollbarAdapter(scrollState),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp),
+                    style = morpheScrollbarStyle()
                 )
             }
         }

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionScreen.kt
@@ -54,6 +54,7 @@ import app.morphe.gui.ui.components.ErrorDialog
 import app.morphe.gui.ui.components.DeviceIndicator
 import app.morphe.gui.ui.components.MorpheSwitch
 import app.morphe.gui.ui.components.SettingsButton
+import app.morphe.gui.ui.components.morpheScrollbarStyle
 import app.morphe.gui.ui.components.getErrorType
 import app.morphe.gui.ui.components.getFriendlyErrorMessage
 import app.morphe.gui.ui.screens.patching.PatchingScreen
@@ -481,7 +482,8 @@ fun PatchSelectionScreenContent(viewModel: PatchSelectionViewModel) {
 
                     androidx.compose.foundation.VerticalScrollbar(
                         modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
-                        adapter = androidx.compose.foundation.rememberScrollbarAdapter(lazyListState)
+                        adapter = androidx.compose.foundation.rememberScrollbarAdapter(lazyListState),
+                        style = morpheScrollbarStyle()
                     )
                 }
 

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchSelectionViewModel.kt
@@ -38,6 +38,9 @@ class PatchSelectionViewModel(
     // Actual path to use - may differ from patchesFilePath if we had to re-download
     private var actualPatchesFilePath: String = patchesFilePath
 
+    // User-configured output folder; null means save next to the input APK.
+    private var defaultOutputDirectory: String? = null
+
     private val _uiState = MutableStateFlow(PatchSelectionUiState(
         apkArchitectures = apkArchitectures,
         stripLibsStatus = computeStripLibsStatus(apkArchitectures, ANDROID_ARCHITECTURES)
@@ -52,6 +55,7 @@ class PatchSelectionViewModel(
     private fun loadStripLibsPreference() {
         screenModelScope.launch {
             val config = configRepository.loadConfig()
+            defaultOutputDirectory = config.defaultOutputDirectory
             _uiState.value = _uiState.value.copy(
                 stripLibsStatus = computeStripLibsStatus(apkArchitectures, config.keepArchitectures)
             )
@@ -210,10 +214,10 @@ class PatchSelectionViewModel(
     }
 
     fun createPatchConfig(continueOnError: Boolean = false): PatchConfig {
-        // Create app folder in the same location as the input APK
         val inputFile = File(apkPath)
         val appFolderName = apkName.replace(" ", "-")
-        val outputDir = File(inputFile.parentFile, appFolderName)
+        val baseOutputDir = defaultOutputDirectory?.let { File(it) } ?: inputFile.parentFile
+        val outputDir = File(baseOutputDir, appFolderName)
         outputDir.mkdirs()
 
         // Extract version from APK filename and patches version for output name

--- a/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchesScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/patches/PatchesScreen.kt
@@ -15,8 +15,11 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -45,6 +48,7 @@ import cafe.adriel.voyager.koin.koinScreenModel
 import app.morphe.gui.ui.components.ErrorDialog
 import app.morphe.gui.ui.components.DeviceIndicator
 import app.morphe.gui.ui.components.SettingsButton
+import app.morphe.gui.ui.components.morpheScrollbarStyle
 import app.morphe.gui.ui.components.getErrorType
 import app.morphe.gui.ui.components.getFriendlyErrorMessage
 import app.morphe.gui.ui.components.OfflineBanner
@@ -310,25 +314,37 @@ fun PatchesScreenContent(viewModel: PatchesViewModel) {
                 }
                 else -> {
                     // Releases list
-                    LazyColumn(
+                    val releasesListState = rememberLazyListState()
+                    Box(
                         modifier = Modifier
                             .weight(1f)
-                            .fillMaxWidth(),
-                        contentPadding = PaddingValues(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                            .fillMaxWidth()
                     ) {
-                        items(
-                            items = uiState.currentReleases,
-                            key = { it.tagName }
-                        ) { release ->
-                            ReleaseCard(
-                                release = release,
-                                isSelected = release.tagName == uiState.selectedRelease?.tagName,
-                                isDownloaded = release.tagName in uiState.cachedReleaseVersions,
-                                isOffline = uiState.isOffline,
-                                onClick = { viewModel.selectRelease(release) }
-                            )
+                        LazyColumn(
+                            state = releasesListState,
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            items(
+                                items = uiState.currentReleases,
+                                key = { it.tagName }
+                            ) { release ->
+                                ReleaseCard(
+                                    release = release,
+                                    isSelected = release.tagName == uiState.selectedRelease?.tagName,
+                                    isDownloaded = release.tagName in uiState.cachedReleaseVersions,
+                                    isOffline = uiState.isOffline,
+                                    onClick = { viewModel.selectRelease(release) }
+                                )
+                            }
                         }
+
+                        VerticalScrollbar(
+                            modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+                            adapter = rememberScrollbarAdapter(releasesListState),
+                            style = morpheScrollbarStyle()
+                        )
                     }
 
                     // Bottom action bar

--- a/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchScreen.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchScreen.kt
@@ -45,6 +45,7 @@ import app.morphe.gui.data.repository.ConfigRepository
 import app.morphe.gui.data.repository.PatchSourceManager
 import app.morphe.gui.ui.components.OfflineBanner
 import app.morphe.gui.ui.components.TopBarRow
+import app.morphe.gui.ui.components.morpheScrollbarStyle
 import app.morphe.gui.ui.screens.home.components.FullScreenDropZone
 import app.morphe.gui.ui.theme.*
 import app.morphe.gui.util.ChecksumStatus
@@ -1527,10 +1528,11 @@ private fun SupportedAppsRow(
 
                 // Horizontal scrolling cards
                 val useScrolling = filteredApps.size > 4
+                val cardsScrollState = rememberScrollState()
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .then(if (useScrolling) Modifier.horizontalScroll(rememberScrollState()) else Modifier)
+                        .then(if (useScrolling) Modifier.horizontalScroll(cardsScrollState) else Modifier)
                         .height(IntrinsicSize.Max)
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
@@ -1627,6 +1629,15 @@ private fun SupportedAppsRow(
                             }
                         }
                     }
+                }
+
+                if (useScrolling && cardsScrollState.maxValue > 0) {
+                    Spacer(Modifier.height(6.dp))
+                    HorizontalScrollbar(
+                        adapter = rememberScrollbarAdapter(cardsScrollState),
+                        modifier = Modifier.fillMaxWidth(),
+                        style = morpheScrollbarStyle()
+                    )
                 }
             }
         }

--- a/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchViewModel.kt
+++ b/src/main/kotlin/app/morphe/gui/ui/screens/quick/QuickPatchViewModel.kt
@@ -458,8 +458,12 @@ class QuickPatchViewModel(
             )
 
             // Generate output path
-            val outputDir = apkFile.parentFile ?: File(System.getProperty("user.home"))
+            val appConfig = configRepository.loadConfig()
             val baseName = apkInfo.displayName.replace(" ", "-")
+            val baseOutputDir = appConfig.defaultOutputDirectory?.let { File(it) }
+                ?: apkFile.parentFile
+                ?: File(System.getProperty("user.home"))
+            val outputDir = File(baseOutputDir, baseName).also { it.mkdirs() }
             val patchesVersion = Regex("""(\d+\.\d+\.\d+(?:-dev\.\d+)?)""")
                 .find(patchFile.name)?.groupValues?.get(1)
             val patchesSuffix = if (patchesVersion != null) "-patches-$patchesVersion" else ""
@@ -467,7 +471,6 @@ class QuickPatchViewModel(
             val outputPath = File(outputDir, outputFileName).absolutePath
 
             // Resolve keystore: use saved path, or derive from output APK location
-            val appConfig = configRepository.loadConfig()
             val resolvedKeystorePath = appConfig.keystorePath
                 ?: File(outputPath).let { out ->
                     out.resolveSibling(out.nameWithoutExtension + ".keystore").absolutePath


### PR DESCRIPTION
Settings Dialog now also has the ability to set a custom path for output apks.
Made the scrollbar a centralized component that can now used on different screen and properly adheres to our design standards.

Should close (#125 and #126)