### PR TITLE
fix: signing improvements

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -15,9 +15,8 @@ import app.morphe.engine.isWindows
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_KEYSTORE_ALIAS
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_KEYSTORE_PASSWORD
 import app.morphe.engine.PatchEngine.Config.Companion.DEFAULT_SIGNER_NAME
-import app.morphe.engine.PatchEngine.Config.Companion.LEGACY_KEYSTORE_ALIAS
-import app.morphe.engine.PatchEngine.Config.Companion.LEGACY_KEYSTORE_PASSWORD
 import app.morphe.engine.UpdateChecker
+import app.morphe.engine.util.signWithLegacyFallback
 import app.morphe.engine.patches.LoadedBundle
 import app.morphe.engine.patches.PatchBundleLoader
 import app.morphe.library.installation.installer.*
@@ -836,33 +835,18 @@ internal object PatchCommand : Callable<Int> {
                     patchingResult.addStepResult(
                         PatchingStep.SIGNING,
                         {
-                            fun signApk(alias: String, password: String) {
-                                ApkUtils.signApk(
-                                    patchedApkFile,
-                                    outputFilePath,
-                                    signer,
-                                    ApkUtils.KeyStoreDetails(
-                                        keystoreFilePath,
-                                        keyStorePassword,
-                                        alias,
-                                        password,
-                                    )
-                                )
-                            }
-                            try {
-                                signApk(keyStoreEntryAlias, keyStoreEntryPassword)
-                            } catch (e: Exception){
-                                // Retry with legacy keystore defaults.
-                                if (keyStoreEntryAlias == DEFAULT_KEYSTORE_ALIAS &&
-                                    keyStoreEntryPassword == DEFAULT_KEYSTORE_PASSWORD &&
-                                    keystoreFilePath.exists()
-                                ) {
-                                    logger.info("Using legacy keystore credentials")
-
-                                    signApk(LEGACY_KEYSTORE_ALIAS, LEGACY_KEYSTORE_PASSWORD)
-                                } else {
-                                    throw e
-                                }
+                            signWithLegacyFallback(
+                                primary = ApkUtils.KeyStoreDetails(
+                                    keystoreFilePath,
+                                    keyStorePassword,
+                                    keyStoreEntryAlias,
+                                    keyStoreEntryPassword,
+                                ),
+                                allowLegacyFallback = keyStoreEntryAlias == DEFAULT_KEYSTORE_ALIAS &&
+                                    keyStoreEntryPassword == DEFAULT_KEYSTORE_PASSWORD,
+                                logger = logger,
+                            ) { details ->
+                                ApkUtils.signApk(patchedApkFile, outputFilePath, signer, details)
                             }
                         }
                     )

--- a/src/main/kotlin/app/morphe/engine/PatchEngine.kt
+++ b/src/main/kotlin/app/morphe/engine/PatchEngine.kt
@@ -8,6 +8,7 @@
 
 package app.morphe.engine
 
+import app.morphe.engine.util.signWithLegacyFallback
 import app.morphe.patcher.Patcher
 import app.morphe.patcher.PatcherConfig
 import app.morphe.patcher.apk.ApkMerger
@@ -244,32 +245,17 @@ object PatchEngine {
                     }
 
                     try {
-                        fun signApk(details: ApkUtils.KeyStoreDetails) {
+                        signWithLegacyFallback(
+                            primary = keystoreDetails,
+                            allowLegacyFallback = config.keystoreDetails == null,
+                            logger = logger,
+                        ) { details ->
                             ApkUtils.signApk(
                                 rebuiltApk,
                                 tempOutput,
                                 config.signerName,
                                 details,
                             )
-                        }
-
-                        try {
-                            signApk(keystoreDetails)
-                        } catch (e: Exception) {
-                            // Retry with legacy keystore defaults.
-                            if (config.keystoreDetails == null && keystoreDetails.keyStore.exists()) {
-                                logger.info("Using legacy keystore credentials")
-
-                                val legacyKeystoreDetails = ApkUtils.KeyStoreDetails(
-                                    keystoreDetails.keyStore,
-                                    null,
-                                    Config.LEGACY_KEYSTORE_ALIAS,
-                                    Config.LEGACY_KEYSTORE_PASSWORD,
-                                )
-                                signApk(legacyKeystoreDetails)
-                            } else {
-                                throw e
-                            }
                         }
                         stepResults.add(StepResult(PatchStep.SIGNING, true))
                     } catch (e: Exception) {

--- a/src/main/kotlin/app/morphe/engine/util/KeystoreSigner.kt
+++ b/src/main/kotlin/app/morphe/engine/util/KeystoreSigner.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-cli
+ */
+
+package app.morphe.engine.util
+
+import app.morphe.engine.PatchEngine
+import app.morphe.patcher.apk.ApkUtils
+import java.util.logging.Logger
+
+/**
+ * Signs an APK with [primary] credentials, falling back to the legacy ("Morphe Key" / empty password) entry.
+ * The legacy retry only fires when [allowLegacyFallback] is true AND the keystore file already exists,
+ * i.e. the user is on default credentials and we're reading a pre-existing keystore that might predate the current alias.
+ * This preserves the exact condition both call sites (CLI + engine) used before.
+ *
+ * On double failure the PRIMARY exception is thrown (legacy attached as suppressed).
+ * The primary error is the meaningful one: the user expects the current Morphe key,
+ * so "no 'Morphe' entry" is more actionable than whatever the legacy retry hit.
+ * The old behavior threw the *legacy* failure, which surfaced confusing errors.
+ *
+ * [sign] performs the actual signing; callers wrap this call with their own progress / step-result reporting.
+ */
+fun signWithLegacyFallback(
+    primary: ApkUtils.KeyStoreDetails,
+    allowLegacyFallback: Boolean,
+    logger: Logger,
+    sign: (ApkUtils.KeyStoreDetails) -> Unit,
+) {
+    try {
+        sign(primary)
+    } catch (primaryError: Exception) {
+        if (!allowLegacyFallback || !primary.keyStore.exists()) throw primaryError
+
+        // Never silently swallow the real cause. Always log it before the back-compat path.
+        logger.info(
+            "Default keystore credentials failed (${primaryError.message}). Retrying with legacy credentials"
+        )
+
+        val legacy = ApkUtils.KeyStoreDetails(
+            primary.keyStore,
+            primary.keyStorePassword,
+            PatchEngine.Config.LEGACY_KEYSTORE_ALIAS,
+            PatchEngine.Config.LEGACY_KEYSTORE_PASSWORD,
+        )
+        try {
+            sign(legacy)
+        } catch (legacyError: Exception) {
+            primaryError.addSuppressed(legacyError)
+            throw primaryError
+        }
+    }
+}


### PR DESCRIPTION
When the default keystore alias/password fails, we log that failure and retry with legacy credentials. Before, the primary failure was swallowed and if the legacy stuff also failed, only the legacy error surfaced. Now we log both the primary failure and legacy error if legacy also fails (legacy attached as suppressed).