### PR TITLE
fix: CLI --purge command does not cleanup temp APK

### DIFF
--- a/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
+++ b/src/main/kotlin/app/morphe/cli/command/PatchCommand.kt
@@ -823,7 +823,7 @@ internal object PatchCommand : Callable<Int> {
 
             // region Save.
 
-            inputApk.copyTo(temporaryFilesPath.resolve(inputApk.name), overwrite = true).apply {
+            inputApk.copyTo(patcherTemporaryFilesPath.resolve(inputApk.name), overwrite = true).apply {
                 patchingResult.addStepResult(
                     PatchingStep.REBUILDING,
                     {


### PR DESCRIPTION
Moved our temp apk from tmp folder in our morphe-data folder to the temp folder used when patching. `--purge` should now properly clean up this file. 